### PR TITLE
Windows users can run 'rsshell' (without '.py') too! Needs testing (on Windows).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ def install_python_modules (modules):
 
 windows_rsshell_forward_script = """
 @echo off
-start "rsshell" /b {0}
+start "rsshell" /b /wait {0}
 """
 
 welcome_msg = """


### PR DESCRIPTION
The title says it all. If ".py" is not normally in PATHEXT, `setup.py` will install a small forwarding script which does have its extension in PATHEXT: `rsshell.cmd`. It's created on the fly.

Testing:

```

 1. cd %RED_SPIDER_ROOT%

 2. # if you don't have me already:
    git remote add julian git://github.com/jgonggrijp/the-red-spider-project.git

 3. git fetch julian
    git checkout julian/rsshell-ext
    setup.py
    # say yes when it asks whether you want to install

 4. rsshell.py cd
    # should produce two lines containing paths,
    # the first starting with "RED_SPIDER_ROOT ="
    # if not, log out of your computer and log back in before you proceed
    # note: no need to exit because of the "cd" argument

 5. rsshell
    # should print the welcome message with "RED_SPIDER_ROOT = ..."

 6. exit
```
