### PR TITLE
Fixed setup.py tab/space mixing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ def install_scripts (src_names, bin_names):
             copy2(src_file, bin_file)
             if not os.access(bin_file, os.X_OK):
                 from stat import *
-								mode = os.stat(bin_file).st_mode
+                mode = os.stat(bin_file).st_mode
                 os.chmod(bin_file, mode | S_IXUSR | S_IXGRP | S_IXOTH)
 
 def install_python_modules (modules):


### PR DESCRIPTION
This fixes issue #55.

Note:
This looks the same in github, because github converts tabs to spaces, but the file _is_ different.
