### PR TITLE
Changed setup.py's extend_user_env_posix to not rewrite every time.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,6 @@ def extend_user_env_posix (name, value, mode):
         if (not '\nexport {0}={1}\n'.format(name, value) in profiletext):
             profile.write('\nexport {0}={1}\n'.format(name, value))
 
-    if (not '\nexport PATH=$PATH:${0}\n'.format(name, value) in profiletext): # I can't think of a better way to do this... :(
-        profile.write('\nexport PATH=$PATH:${0}\n'.format(name, value))
     profile.close()
 
 def install ( ):


### PR DESCRIPTION
I changed setup.py's extend_user_env_posix function.  This change means 2 things:

1.) extend_user_env_posix writes to ~/.bashrc, not ~/.profile.  It's more widly used and doesn't require a new login, just a new virtual terminal.
2.) extend_user_env_posix will check if it needs to write to ~/.bashrc, and only write if ~/.bashrc doesn't include an export statment for the current directory.
